### PR TITLE
Use suffix for float and double literals

### DIFF
--- a/src/Tars.Net.Codecs/DoubleTarsConvert.cs
+++ b/src/Tars.Net.Codecs/DoubleTarsConvert.cs
@@ -19,7 +19,7 @@ namespace Tars.Net.Codecs
                     return buffer.ReadDouble();
 
                 case TarsStructType.Zero:
-                    return 0x0;
+                    return 0D;
 
                 default:
                     throw new TarsDecodeException($"DoubleTarsConvert can not deserialize {options}");

--- a/src/Tars.Net.Codecs/FloatTarsConvert.cs
+++ b/src/Tars.Net.Codecs/FloatTarsConvert.cs
@@ -16,7 +16,7 @@ namespace Tars.Net.Codecs
             switch (options.TarsType)
             {
                 case TarsStructType.Zero:
-                    return 0x0;
+                    return 0F;
 
                 case TarsStructType.Float:
                     return buffer.ReadFloat();


### PR DESCRIPTION
C# Reference

[float](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/float)
[double](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/double)